### PR TITLE
PCSM-274 async bulk write pipeline

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -26,7 +26,7 @@ Starts the replication process.
 |-----------|------|----------|-------------|
 | `includeNamespaces` | string[] | No | List of namespaces to include in replication (for example, ["db.*", "db.collection"]) |
 | `excludeNamespaces` | string[] | No | List of namespaces to exclude from replication |
-| `replWorkerFlushInterval` | string[] | No | Maximum time between bulk write flushes to the target. Lower values reduce lag and higher values batch more ops per write. |
+| `replWorkerFlushInterval` | string | No | Maximum time between bulk write flushes to the target. Lower values reduce lag and higher values batch more ops per write. |
 | `replWorkerBulkQueueSize` | integer | No | Number of pending bulks per worker for asynchronous writes. Higher values may improve throughput but increase memory usage. |
 
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -24,9 +24,9 @@ Starts the replication process.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `includeNamespaces` | string | No | List of namespaces to include in replication (for example, ["db.*", "db.collection"]) |
-| `excludeNamespaces` | string | No | List of namespaces to exclude from replication |
-| `replWorkerFlushInterval` | string | No | Maximum time between bulk write flushes to the target. Lower values reduce lag and higher values batch more ops per write. |
+| `includeNamespaces` | string[] | No | List of namespaces to include in replication (for example, ["db.*", "db.collection"]) |
+| `excludeNamespaces` | string[] | No | List of namespaces to exclude from replication |
+| `replWorkerFlushInterval` | string[] | No | Maximum time between bulk write flushes to the target. Lower values reduce lag and higher values batch more ops per write. |
 | `replWorkerBulkQueueSize` | integer | No | Number of pending bulks per worker for asynchronous writes. Higher values may improve throughput but increase memory usage. |
 
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -32,7 +32,7 @@ Starts the replication process.
 
 Example:
 
-```json
+```bash
 curl -X POST http://localhost:2242/start -d '{
     "includeNamespaces": ["dbName.*", "anotherDB.collName1", "anotherDB.collName2"],
     "excludeNamespaces": ["dbName.collName"],

--- a/docs/api.md
+++ b/docs/api.md
@@ -26,6 +26,9 @@ Starts the replication process.
 |-----------|------|----------|-------------|
 | `includeNamespaces` | string[] | No | List of namespaces to include in replication (for example, ["db.*", "db.collection"]) |
 | `excludeNamespaces` | string[] | No | List of namespaces to exclude from replication |
+| `replWorkerFlushInterval` | string[] | No | Maximum time between bulk write flushes to the target. Lower values reduce lag and higher values batch more ops per write.  |
+| `--repl-worker-bulk-queue-size` | integer | No | Number of pending bulks per worker for asynchronous writes. Higher values may improve throughput but increase memory usage. |
+
 
 Example:
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -24,8 +24,8 @@ Starts the replication process.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `includeNamespaces` | string[] | No | List of namespaces to include in replication (for example, ["db.*", "db.collection"]) |
-| `excludeNamespaces` | string[] | No | List of namespaces to exclude from replication |
+| `includeNamespaces` | string | No | List of namespaces to include in replication (for example, ["db.*", "db.collection"]) |
+| `excludeNamespaces` | string | No | List of namespaces to exclude from replication |
 | `replWorkerFlushInterval` | string | No | Maximum time between bulk write flushes to the target. Lower values reduce lag and higher values batch more ops per write. |
 | `replWorkerBulkQueueSize` | integer | No | Number of pending bulks per worker for asynchronous writes. Higher values may improve throughput but increase memory usage. |
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -26,8 +26,8 @@ Starts the replication process.
 |-----------|------|----------|-------------|
 | `includeNamespaces` | string[] | No | List of namespaces to include in replication (for example, ["db.*", "db.collection"]) |
 | `excludeNamespaces` | string[] | No | List of namespaces to exclude from replication |
-| `replWorkerFlushInterval` | string[] | No | Maximum time between bulk write flushes to the target. Lower values reduce lag and higher values batch more ops per write.  |
-| `--repl-worker-bulk-queue-size` | integer | No | Number of pending bulks per worker for asynchronous writes. Higher values may improve throughput but increase memory usage. |
+| `replWorkerFlushInterval` | string | No | Maximum time between bulk write flushes to the target. Lower values reduce lag and higher values batch more ops per write.  |
+| `replWorkerBulkQueueSize` | integer | No | Number of pending bulks per worker for asynchronous writes. Higher values may improve throughput but increase memory usage. |
 
 
 Example:
@@ -35,7 +35,9 @@ Example:
 ```json
 curl -X POST http://localhost:2242/start -d '{
     "includeNamespaces": ["dbName.*", "anotherDB.collName1", "anotherDB.collName2"],
-    "excludeNamespaces": ["dbName.collName"]
+    "excludeNamespaces": ["dbName.collName"],
+    "replWorkerFlushInterval": "1s",
+    "replWorkerBulkQueueSize": 10
 }'
 ```
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -37,7 +37,7 @@ curl -X POST http://localhost:2242/start -d '{
     "includeNamespaces": ["dbName.*", "anotherDB.collName1", "anotherDB.collName2"],
     "excludeNamespaces": ["dbName.collName"],
     "replWorkerFlushInterval": "1s",
-    "replWorkerBulkQueueSize": 10
+    "replWorkerBulkQueueSize": 3
 }'
 ```
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -26,7 +26,7 @@ Starts the replication process.
 |-----------|------|----------|-------------|
 | `includeNamespaces` | string[] | No | List of namespaces to include in replication (for example, ["db.*", "db.collection"]) |
 | `excludeNamespaces` | string[] | No | List of namespaces to exclude from replication |
-| `replWorkerFlushInterval` | string | No | Maximum time between bulk write flushes to the target. Lower values reduce lag and higher values batch more ops per write.  |
+| `replWorkerFlushInterval` | string[] | No | Maximum time between bulk write flushes to the target. Lower values reduce lag and higher values batch more ops per write.  |
 | `replWorkerBulkQueueSize` | integer | No | Number of pending bulks per worker for asynchronous writes. Higher values may improve throughput but increase memory usage. |
 
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -26,7 +26,7 @@ Starts the replication process.
 |-----------|------|----------|-------------|
 | `includeNamespaces` | string[] | No | List of namespaces to include in replication (for example, ["db.*", "db.collection"]) |
 | `excludeNamespaces` | string[] | No | List of namespaces to exclude from replication |
-| `replWorkerFlushInterval` | string[] | No | Maximum time between bulk write flushes to the target. Lower values reduce lag and higher values batch more ops per write.  |
+| `replWorkerFlushInterval` | string | No | Maximum time between bulk write flushes to the target. Lower values reduce lag and higher values batch more ops per write. |
 | `replWorkerBulkQueueSize` | integer | No | Number of pending bulks per worker for asynchronous writes. Higher values may improve throughput but increase memory usage. |
 
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -60,7 +60,7 @@ Finalizes the replication process.
 
 Example:
 
-```json
+```bash
 curl -X POST http://localhost:2242/finalize
 ```
 
@@ -83,7 +83,7 @@ Pauses the replication process.
 
 Example:
 
-```json
+```bash
 curl -X POST http://localhost:2242/pause
 ```
 
@@ -106,13 +106,13 @@ Resumes the replication process.
 
 Example:
 
-```json
+```bash
 curl -X POST http://localhost:2242/resume
 ```
 
 Resume from failure:
 
-```json
+```bash
 curl -X POST http://localhost:2242/resume -d '{
   "fromFailure": true
 }'
@@ -137,7 +137,7 @@ The /status endpoint provides the current state of the Percona ClusterSync for M
 
 Example:
 
-```json
+```bash
 curl -X GET http://localhost:2242/status
 ```
 

--- a/docs/install/parameters.md
+++ b/docs/install/parameters.md
@@ -32,4 +32,6 @@ Alternatively, you can define the following environment variables:
 | `PCSM_CLONE_NUM_PARALLEL_COLLECTIONS` | Number of collections cloned in parallel | `2` |
 | `PCSM_CLONE_NUM_READ_WORKERS` | Number of read workers for cloning | `NumCPU / 4` |
 | `PCSM_CLONE_NUM_INSERT_WORKERS` | Number of insert workers for cloning | `NumCPU * 4` |
-| `PCSM_MONGODB_CLI_OPERATION_TIMEOUT` | Maximum time to wait before timing out MongoDB client operations such as insert, update, delete. If the timeout is reached, the operation will fail.  | `5m` |  
+| `PCSM_MONGODB_CLI_OPERATION_TIMEOUT` | Maximum time to wait before timing out MongoDB client operations such as insert, update, delete. If the timeout is reached, the operation will fail.  | `5m` |
+| `PCSM_REPL_WORKER_FLUSH_INTERVAL` | Maximum time between bulk write flushes to the target. Lower values reduce lag and higher values batch more ops per write. | `1s` |
+| `PCSM_REPL_WORKER_BULK_QUEUE_SIZE` | Number of pending bulk batches per worker while a write is in progress. Higher values can improve throughput at the cost of increased memory usage. | `3` |   

--- a/docs/install/parameters.md
+++ b/docs/install/parameters.md
@@ -34,4 +34,4 @@ Alternatively, you can define the following environment variables:
 | `PCSM_CLONE_NUM_INSERT_WORKERS` | Number of insert workers for cloning | `NumCPU * 4` |
 | `PCSM_MONGODB_CLI_OPERATION_TIMEOUT` | Maximum time to wait before timing out MongoDB client operations such as insert, update, delete. If the timeout is reached, the operation will fail.  | `5m` |
 | `PCSM_REPL_WORKER_FLUSH_INTERVAL` | Maximum time between bulk write flushes to the target. Lower values reduce lag and higher values batch more ops per write. | `1s` |
-| `PCSM_REPL_WORKER_BULK_QUEUE_SIZE` | Number of pending bulk batches per worker while a write is in progress. Higher values can improve throughput at the cost of increased memory usage. | `3` |   
+| `PCSM_REPL_WORKER_BULK_QUEUE_SIZE` | Number of pending bulk batches per worker while a write is in progress. Higher values can improve throughput at the cost of increased memory usage. | `3` |

--- a/docs/install/parameters.md
+++ b/docs/install/parameters.md
@@ -8,6 +8,8 @@ When [starting the `pcsm` process](start-pcsm.md), you can use the following opt
 - `--log-level`: The log level (default: "info")
 - `--log-json`: Output log in JSON format with disabled color
 - `--no-color`: Disable log ASCI color
+- `--source-client-compressors`: Specifies which compression algorithms the source client should use when reading events/documents as a comma-separated list. Accepted values: `snappy`, `zstd`, `zlib`. Useful because throughput can vary dramatically depending on how compressible the source data is.
+- `--target-client-compressors`: Specifies which compression algorithms the target client should use when writing events/documents as a comma-separated list. Accepted values: `snappy`, `zstd`, `zlib`. Set to an empty string to disable compression.
 
 Example:
 
@@ -35,3 +37,5 @@ Alternatively, you can define the following environment variables:
 | `PCSM_MONGODB_CLI_OPERATION_TIMEOUT` | Maximum time to wait before timing out MongoDB client operations such as insert, update, delete. If the timeout is reached, the operation will fail.  | `5m` |
 | `PCSM_REPL_WORKER_FLUSH_INTERVAL` | Maximum time between bulk write flushes to the target. Lower values reduce lag and higher values batch more ops per write. | `1s` |
 | `PCSM_REPL_WORKER_BULK_QUEUE_SIZE` | Number of pending bulk batches per worker while a write is in progress. Higher values can improve throughput at the cost of increased memory usage. | `3` |
+| `PCSM_SOURCE_CLIENT_COMPRESSORS` | Specifies which compression algorithms the source client should use when reading events/documents as a comma-separated list. Accepted values: `snappy`, `zstd`, `zlib`. Useful because throughput can vary dramatically depending on how compressible the source data is. | `snappy,zstd,zlib` |
+| `PCSM_TARGET_CLIENT_COMPRESSORS` | Specifies which compression algorithms the target client should use when writing events/documents as a comma-separated list. Accepted values: `snappy`, `zstd`, `zlib`. Set to an empty string to disable compression. | `snappy,zstd,zlib` |

--- a/docs/pcsm-commands.md
+++ b/docs/pcsm-commands.md
@@ -47,7 +47,6 @@ Available flags:
 | -----| -----------|
 | `--include-namespaces` | Replicate only the specified namespaces. Multiple namespaces are supported as a comma separated list. The number of namespaces to specify is unlimited|
 | `--exclude-namespaces` | Replicate everything except the specified namespaces. Multiple namespaces are supported as a comma separated list. The number of namespaces to specify is unlimited. <br> When both `--include-namespaces` and  `--exclude-namespaces` flags are specified, the exclude filters take precedence. For example, if the `--include-namespaces` includes `db1.*` and `--exclude-namespaces` has `db1.users`, {{pcsm.short}} syncs all collections of `db1` **except** `db1.users`.|
-| `--include-namespaces` | Replicate only the specified namespaces. Multiple namespaces are supported as a comma separated list. The number of namespaces to specify is unlimited|
 | `--repl-worker-flush-interval` | Maximum interval between worker bulk write flushes (for example, 1s, 500ms). Default: 1s.|
 | `--repl-worker-bulk-queue-size` | Number of pending bulks per worker for asynchronous writes. Higher values may improve throughput but increase memory usage.|
 

--- a/docs/pcsm-commands.md
+++ b/docs/pcsm-commands.md
@@ -47,7 +47,7 @@ Available flags:
 | -----| -----------|
 | `--include-namespaces` | Replicate only the specified namespaces. Multiple namespaces are supported as a comma separated list. The number of namespaces to specify is unlimited|
 | `--exclude-namespaces` | Replicate everything except the specified namespaces. Multiple namespaces are supported as a comma separated list. The number of namespaces to specify is unlimited. <br> When both `--include-namespaces` and  `--exclude-namespaces` flags are specified, the exclude filters take precedence. For example, if the `--include-namespaces` includes `db1.*` and `--exclude-namespaces` has `db1.users`, {{pcsm.short}} syncs all collections of `db1` **except** `db1.users`.|
-| `--repl-worker-flush-interval` | Maximum interval between worker bulk write flushes (for example, 1s, 500ms). Default: 1s.|
+| `--repl-worker-flush-interval` | Maximum interval between worker bulk write flushes (for example, 1s, 500ms).|
 | `--repl-worker-bulk-queue-size` | Number of pending bulks per worker for asynchronous writes. Higher values may improve throughput but increase memory usage.|
 
 

--- a/docs/pcsm-commands.md
+++ b/docs/pcsm-commands.md
@@ -47,6 +47,9 @@ Available flags:
 | -----| -----------|
 | `--include-namespaces` | Replicate only the specified namespaces. Multiple namespaces are supported as a comma separated list. The number of namespaces to specify is unlimited|
 | `--exclude-namespaces` | Replicate everything except the specified namespaces. Multiple namespaces are supported as a comma separated list. The number of namespaces to specify is unlimited. <br> When both `--include-namespaces` and  `--exclude-namespaces` flags are specified, the exclude filters take precedence. For example, if the `--include-namespaces` includes `db1.*` and `--exclude-namespaces` has `db1.users`, {{pcsm.short}} syncs all collections of `db1` **except** `db1.users`.|
+| `--include-namespaces` | Replicate only the specified namespaces. Multiple namespaces are supported as a comma separated list. The number of namespaces to specify is unlimited|
+| `--repl-worker-flush-interval` | Maximum interval between worker bulk write flushes (for example, 1s, 500ms). Default: 1s.|
+| `--repl-worker-bulk-queue-size` | Number of pending bulks per worker for asynchronous writes. Higher values may improve throughput but increase memory usage.|
 
 
 ### reset

--- a/docs/pcsm-commands.md
+++ b/docs/pcsm-commands.md
@@ -43,7 +43,7 @@ To include or exclude a specific database and all collections it includes, pass 
 Available flags:
 
 
-| Name | Description|| Default |
+| Name | Description| Default |
 | -----| -----------|----------|
 | `--include-namespaces` | Replicate only the specified namespaces. Multiple namespaces are supported as a comma separated list. The number of namespaces to specify is unlimited| |
 | `--exclude-namespaces` | Replicate everything except the specified namespaces. Multiple namespaces are supported as a comma separated list. The number of namespaces to specify is unlimited. <br> When both `--include-namespaces` and  `--exclude-namespaces` flags are specified, the exclude filters take precedence. For example, if the `--include-namespaces` includes `db1.*` and `--exclude-namespaces` has `db1.users`, {{pcsm.short}} syncs all collections of `db1` **except** `db1.users`.| |

--- a/docs/pcsm-commands.md
+++ b/docs/pcsm-commands.md
@@ -43,12 +43,12 @@ To include or exclude a specific database and all collections it includes, pass 
 Available flags:
 
 
-| Name | Description|
-| -----| -----------|
-| `--include-namespaces` | Replicate only the specified namespaces. Multiple namespaces are supported as a comma separated list. The number of namespaces to specify is unlimited|
-| `--exclude-namespaces` | Replicate everything except the specified namespaces. Multiple namespaces are supported as a comma separated list. The number of namespaces to specify is unlimited. <br> When both `--include-namespaces` and  `--exclude-namespaces` flags are specified, the exclude filters take precedence. For example, if the `--include-namespaces` includes `db1.*` and `--exclude-namespaces` has `db1.users`, {{pcsm.short}} syncs all collections of `db1` **except** `db1.users`.|
-| `--repl-worker-flush-interval` | Maximum time between bulk write flushes to the target. Lower values reduce lag and higher values batch more ops per write (for example, 1s, 500ms).|
-| `--repl-worker-bulk-queue-size` | Number of pending bulks per worker for asynchronous writes. Higher values may improve throughput but increase memory usage.|
+| Name | Description|| Default |
+| -----| -----------|----------|
+| `--include-namespaces` | Replicate only the specified namespaces. Multiple namespaces are supported as a comma separated list. The number of namespaces to specify is unlimited| |
+| `--exclude-namespaces` | Replicate everything except the specified namespaces. Multiple namespaces are supported as a comma separated list. The number of namespaces to specify is unlimited. <br> When both `--include-namespaces` and  `--exclude-namespaces` flags are specified, the exclude filters take precedence. For example, if the `--include-namespaces` includes `db1.*` and `--exclude-namespaces` has `db1.users`, {{pcsm.short}} syncs all collections of `db1` **except** `db1.users`.| |
+| `--repl-worker-flush-interval` | Maximum time between bulk write flushes to the target. Lower values reduce lag and higher values batch more ops per write (for example, 1s, 500ms).|`1s` |
+| `--repl-worker-bulk-queue-size` | Number of pending bulks per worker for asynchronous writes. Higher values may improve throughput but increase memory usage.| `3`|
 
 
 ### reset

--- a/docs/pcsm-commands.md
+++ b/docs/pcsm-commands.md
@@ -45,8 +45,8 @@ Available flags:
 
 | Name | Description| Default |
 | -----| -----------|----------|
-| `--include-namespaces` | Replicate only the specified namespaces. Multiple namespaces are supported as a comma separated list. The number of namespaces to specify is unlimited| |
-| `--exclude-namespaces` | Replicate everything except the specified namespaces. Multiple namespaces are supported as a comma separated list. The number of namespaces to specify is unlimited. <br> When both `--include-namespaces` and  `--exclude-namespaces` flags are specified, the exclude filters take precedence. For example, if the `--include-namespaces` includes `db1.*` and `--exclude-namespaces` has `db1.users`, {{pcsm.short}} syncs all collections of `db1` **except** `db1.users`.| |
+| `--include-namespaces` | Replicate only the specified namespaces. Multiple namespaces are supported as a comma separated list. The number of namespaces to specify is unlimited| NA|
+| `--exclude-namespaces` | Replicate everything except the specified namespaces. Multiple namespaces are supported as a comma separated list. The number of namespaces to specify is unlimited. <br> When both `--include-namespaces` and  `--exclude-namespaces` flags are specified, the exclude filters take precedence. For example, if the `--include-namespaces` includes `db1.*` and `--exclude-namespaces` has `db1.users`, {{pcsm.short}} syncs all collections of `db1` **except** `db1.users`.| NA|
 | `--repl-worker-flush-interval` | Maximum time between bulk write flushes to the target. Lower values reduce lag and higher values batch more ops per write (for example, 1s, 500ms).|`1s` |
 | `--repl-worker-bulk-queue-size` | Number of pending bulks per worker for asynchronous writes. Higher values may improve throughput but increase memory usage.| `3`|
 

--- a/docs/pcsm-commands.md
+++ b/docs/pcsm-commands.md
@@ -45,8 +45,8 @@ Available flags:
 
 | Name | Description| Default |
 | -----| -----------|----------|
-| `--include-namespaces` | Replicate only the specified namespaces. Multiple namespaces are supported as a comma separated list. The number of namespaces to specify is unlimited| NA|
-| `--exclude-namespaces` | Replicate everything except the specified namespaces. Multiple namespaces are supported as a comma separated list. The number of namespaces to specify is unlimited. <br> When both `--include-namespaces` and  `--exclude-namespaces` flags are specified, the exclude filters take precedence. For example, if the `--include-namespaces` includes `db1.*` and `--exclude-namespaces` has `db1.users`, {{pcsm.short}} syncs all collections of `db1` **except** `db1.users`.| NA|
+| `--include-namespaces` | Replicate only the specified namespaces. Multiple namespaces are supported as a comma separated list. The number of namespaces to specify is unlimited| -|
+| `--exclude-namespaces` | Replicate everything except the specified namespaces. Multiple namespaces are supported as a comma separated list. The number of namespaces to specify is unlimited. <br> When both `--include-namespaces` and  `--exclude-namespaces` flags are specified, the exclude filters take precedence. For example, if the `--include-namespaces` includes `db1.*` and `--exclude-namespaces` has `db1.users`, {{pcsm.short}} syncs all collections of `db1` **except** `db1.users`.| -|
 | `--repl-worker-flush-interval` | Maximum time between bulk write flushes to the target. Lower values reduce lag and higher values batch more ops per write (for example, 1s, 500ms).|`1s` |
 | `--repl-worker-bulk-queue-size` | Number of pending bulks per worker for asynchronous writes. Higher values may improve throughput but increase memory usage.| `3`|
 

--- a/docs/pcsm-commands.md
+++ b/docs/pcsm-commands.md
@@ -47,7 +47,7 @@ Available flags:
 | -----| -----------|
 | `--include-namespaces` | Replicate only the specified namespaces. Multiple namespaces are supported as a comma separated list. The number of namespaces to specify is unlimited|
 | `--exclude-namespaces` | Replicate everything except the specified namespaces. Multiple namespaces are supported as a comma separated list. The number of namespaces to specify is unlimited. <br> When both `--include-namespaces` and  `--exclude-namespaces` flags are specified, the exclude filters take precedence. For example, if the `--include-namespaces` includes `db1.*` and `--exclude-namespaces` has `db1.users`, {{pcsm.short}} syncs all collections of `db1` **except** `db1.users`.|
-| `--repl-worker-flush-interval` | Maximum interval between worker bulk write flushes (for example, 1s, 500ms).|
+| `--repl-worker-flush-interval` | Maximum time between bulk write flushes to the target. Lower values reduce lag and higher values batch more ops per write (for example, 1s, 500ms).|
 | `--repl-worker-bulk-queue-size` | Number of pending bulks per worker for asynchronous writes. Higher values may improve throughput but increase memory usage.|
 
 


### PR DESCRIPTION
- [x] Fix `replWorkerFlushInterval` type from `string[]` to `string` in `/start` API docs
- [x] Rename `--repl-worker-bulk-queue-size` to `replWorkerBulkQueueSize` (camelCase JSON naming convention)
- [x] Update `/start` request example to include new parameters with correct field names
- [x] Fix `/start` example code fence tag from `json` to `bash` (it's a curl command)
- [x] Fix `replWorkerFlushInterval` type still showing as `string[]` in the parameter table (now correctly `string`)
- [x] Fix code fence tags for curl examples in `/finalize`, `/pause`, `/resume`, and `/status` endpoints (changed from `json` to `bash`)

<!-- START COPILOT CODING AGENT TIPS -->
---

💡 You can make Copilot smarter by setting up custom instructions, customizing its development environment and configuring Model Context Protocol (MCP) servers. Learn more [Copilot coding agent tips](https://gh.io/copilot-coding-agent-tips) in the docs.