### PR TITLE
PCSM-323---clone-segment-size

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
 
       #Run check
       - name: reviewdog
-        uses: errata-ai/vale-action@reviewdog
+        uses: errata-ai/vale-action@v2.1.0
         with: 
           vale_flags: "--glob=*.md"
 #          fail_on_error: true
@@ -35,4 +35,3 @@ jobs:
           # Required, set by GitHub actions automatically:
           # https://docs.github.com/en/actions/security-guides/automatic-token-authentication#about-the-github_token-secret
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
 
       #Run check
       - name: reviewdog
-        uses: errata-ai/vale-action@v2.1.0
+        uses: vale-cli/vale-action@v2.1.1
         with: 
           vale_flags: "--glob=*.md"
 #          fail_on_error: true

--- a/docs/api.md
+++ b/docs/api.md
@@ -31,7 +31,7 @@ Starts the replication process.
 | `replEventQueueSize` | int | No | Controls the size of the internal event queue used by the replication subsystem. |
 | `replWorkerQueueSize` | int | No | Defines the maximum number of replication events that each replication worker thread can queue before processing.  |
 | `replBulkOpsSize` | int | No | Defines the maximum number of operations that can be grouped together into a single bulk apply batch during replication. |
-| `cloneSegmentSize` | string | No | Defines the size of each clone segment processed during the initial clone phase. Specify this as a human-readable size string accepted by the server, for example `500MB` or `1GiB`. |
+| `cloneSegmentSize` | string | No | Defines the byte size of each clone segment processed during the initial clone phase. Specify either a plain integer number of bytes (for example, `1048576`) or a human-readable size string accepted by the server, for example `500MB` or `1GiB`. |
 
 
 Examples:

--- a/docs/api.md
+++ b/docs/api.md
@@ -31,6 +31,7 @@ Starts the replication process.
 | `replEventQueueSize` | int | No | Controls the size of the internal event queue used by the replication subsystem. |
 | `replWorkerQueueSize` | int | No | Defines the maximum number of replication events that each replication worker thread can queue before processing.  |
 | `replBulkOpsSize` | int | No | Defines the maximum number of operations that can be grouped together into a single bulk apply batch during replication. |
+| `cloneSegmentSize` | int | No | Defines the size of each clone segment processed during the initial clone phase. |
 
 
 Examples:

--- a/docs/api.md
+++ b/docs/api.md
@@ -31,7 +31,7 @@ Starts the replication process.
 | `replEventQueueSize` | int | No | Controls the size of the internal event queue used by the replication subsystem. |
 | `replWorkerQueueSize` | int | No | Defines the maximum number of replication events that each replication worker thread can queue before processing.  |
 | `replBulkOpsSize` | int | No | Defines the maximum number of operations that can be grouped together into a single bulk apply batch during replication. |
-| `cloneSegmentSize` | int | No | Defines the size of each clone segment processed during the initial clone phase. |
+| `cloneSegmentSize` | string | No | Defines the size of each clone segment processed during the initial clone phase. Specify this as a human-readable size string accepted by the server, for example `500MB` or `1GiB`. |
 
 
 Examples:

--- a/docs/install/parameters.md
+++ b/docs/install/parameters.md
@@ -12,6 +12,7 @@ When [starting the `pcsm` process](start-pcsm.md), you can use the following opt
 - `--clone-num-parallel-collections`: Number of collections cloned in parallel during clone.
 - `--clone-num-read-workers`: Number of read workers that read collection segments from the source. Shared for all collections.
 - `--clone-num-insert-workers`: Number of insert workers that write batches to the target. Shared for all collections.
+- `--clone-segment-size`: Segment size for clone operations. Accepts plain bytes or a unit suffix (e.g. `500MB`, `1GiB`). When omitted, the tool automatically calculates segment size based on collection size and available read workers.
 - `--use-collection-bulk-write`: Forces collection-level bulk write instead of the newer client-level bulk write (MongoDB 8.0+).
 
 

--- a/docs/install/parameters.md
+++ b/docs/install/parameters.md
@@ -39,7 +39,7 @@ Alternatively, you can define the following environment variables:
 | `PCSM_CLONE_NUM_PARALLEL_COLLECTIONS` | Number of collections cloned in parallel | `2` |
 | `PCSM_CLONE_NUM_READ_WORKERS` | Number of read workers for cloning | `NumCPU / 4` |
 | `PCSM_CLONE_NUM_INSERT_WORKERS` | Number of insert workers for cloning | `NumCPU * 4` |
-| `PCSM_CLONE_SEGMENT_SIZE` | Segment size for clone operations. Accepts plain bytes or a unit suffix (e.g. `500MB`, `1GiB`). When not set, segment size is calculated automatically based on collection size and available read workers. | - |
+| `PCSM_CLONE_SEGMENT_SIZE` | Defines the segment size used during clone operations. Accepts values in bytes or with size suffixes such as 500MB or 1GiB. If not specified, PCSM automatically calculates the segment size based on collection size and available read workers. | Auto |
 | `PCSM_MONGODB_CLI_OPERATION_TIMEOUT` | Maximum time to wait before timing out MongoDB client operations such as insert, update, delete. If the timeout is reached, the operation will fail.  | `5m` | 
 | `PCSM_REPL_NUM_WORKERS` | Controls how many concurrent replication worker goroutines PCSM uses to apply DML (insert/update/replace/delete) events to the target cluster. | `runtime.NumCPU()` |
 | `PCSM_REPL_CHANGE_STREAM_BATCH_SIZE` | Sets the maximum number of change stream events PCSM will request and read from MongoDB per batch while streaming changes from the source cluster. | `10000` |

--- a/docs/install/parameters.md
+++ b/docs/install/parameters.md
@@ -39,7 +39,7 @@ Alternatively, you can define the following environment variables:
 | `PCSM_CLONE_NUM_PARALLEL_COLLECTIONS` | Number of collections cloned in parallel | `2` |
 | `PCSM_CLONE_NUM_READ_WORKERS` | Number of read workers for cloning | `NumCPU / 4` |
 | `PCSM_CLONE_NUM_INSERT_WORKERS` | Number of insert workers for cloning | `NumCPU * 4` |
-| `PCSM_CLONE_SEGMENT_SIZE` | Defines the segment size used during clone operations. Accepts values in bytes or with size suffixes such as 500MB or 1GiB. If not specified, PCSM automatically calculates the segment size based on collection size and available read workers. | Auto |
+| `PCSM_CLONE_SEGMENT_SIZE` | Defines the segment size used during clone operations. Accepts values in bytes or with size suffixes such as 500MB or 1GiB. If not specified, PCSM automatically calculates the segment size based on collection size and available read workers. | `Auto` |
 | `PCSM_MONGODB_CLI_OPERATION_TIMEOUT` | Maximum time to wait before timing out MongoDB client operations such as insert, update, delete. If the timeout is reached, the operation will fail.  | `5m` | 
 | `PCSM_REPL_NUM_WORKERS` | Controls how many concurrent replication worker goroutines PCSM uses to apply DML (insert/update/replace/delete) events to the target cluster. | `runtime.NumCPU()` |
 | `PCSM_REPL_CHANGE_STREAM_BATCH_SIZE` | Sets the maximum number of change stream events PCSM will request and read from MongoDB per batch while streaming changes from the source cluster. | `10000` |

--- a/docs/install/parameters.md
+++ b/docs/install/parameters.md
@@ -39,7 +39,7 @@ Alternatively, you can define the following environment variables:
 | `PCSM_CLONE_NUM_PARALLEL_COLLECTIONS` | Number of collections cloned in parallel | `2` |
 | `PCSM_CLONE_NUM_READ_WORKERS` | Number of read workers for cloning | `NumCPU / 4` |
 | `PCSM_CLONE_NUM_INSERT_WORKERS` | Number of insert workers for cloning | `NumCPU * 4` |
-| `PCSM_CLONE_SEGMENT_SIZE` | Defines the segment size used during clone operations. Accepts values in bytes or with size suffixes such as 500MB or 1GiB. If not specified, PCSM automatically calculates the segment size based on collection size and available read workers. | `Auto` |
+| `PCSM_CLONE_SEGMENT_SIZE` | Defines the segment size used during clone operations. Accepts values in bytes or with size suffixes such as `500MB` or `1GiB`. If not specified, PCSM automatically calculates the segment size based on collection size and available read workers. | `Auto` |
 | `PCSM_MONGODB_CLI_OPERATION_TIMEOUT` | Maximum time to wait before timing out MongoDB client operations such as insert, update, delete. If the timeout is reached, the operation will fail.  | `5m` | 
 | `PCSM_REPL_NUM_WORKERS` | Controls how many concurrent replication worker goroutines PCSM uses to apply DML (insert/update/replace/delete) events to the target cluster. | `runtime.NumCPU()` |
 | `PCSM_REPL_CHANGE_STREAM_BATCH_SIZE` | Sets the maximum number of change stream events PCSM will request and read from MongoDB per batch while streaming changes from the source cluster. | `10000` |

--- a/docs/install/parameters.md
+++ b/docs/install/parameters.md
@@ -16,7 +16,7 @@ When [starting the `pcsm` process](start-pcsm.md), you can use the following opt
 - `--use-collection-bulk-write`: Forces collection-level bulk write instead of the newer client-level bulk write (MongoDB 8.0+).
 
 
-??? example "Example"
+??? example "Examples"
 
     ```{.bash data-prompt="$"}
     $ pcsm \
@@ -25,6 +25,40 @@ When [starting the `pcsm` process](start-pcsm.md), you can use the following opt
         --port 2242 \
         --log-level debug \
         --log-json
+    ```
+
+    **--clone-segment-size**
+
+    ```{.bash data-prompt="$"}
+    $ pcsm start --clone-segment-size=1G
+    {
+    "ok": true
+    }
+    ```
+
+    Check the logs
+
+    ```
+    2026-05-21 08:34:50.989 INF Starting HTTP server at     http://localhost:2242
+    2026-05-21 08:37:22.475 INF GET /status s=http
+    2026-05-21 08:43:56.309 INF GET /status s=http
+    2026-05-21 08:44:59.346 INF POST /start s=http
+    2026-05-21 08:44:59.347 INF Config: NumWorkers: 12 s=repl
+    2026-05-21 08:44:59.347 INF Config: UseCollectionBulkWrite: false s=repl
+    2026-05-21 08:44:59.347 INF Config: ChangeStreamBatchSize: 10000 s=repl
+    2026-05-21 08:44:59.347 INF Config: EventQueueSize: 5000 s=repl
+    2026-05-21 08:44:59.347 INF Config: WorkerQueueSize: 5000 s=repl
+    2026-05-21 08:44:59.347 INF Config: BulkOpsSize: 5000 s=repl
+    2026-05-21 08:44:59.347 INF Config: WorkerFlushInterval: 1s s=repl
+    2026-05-21 08:44:59.347 INF Config: WorkerBulkQueueSize: 3 s=repl
+    2026-05-21 08:44:59.347 INF Starting Cluster Replication s=pcsm
+    2026-05-21 08:44:59.347 INF Starting Data Clone s=clone
+    2026-05-21 08:44:59.349 INF Namespace "test_db.collection_0" included ns=test_db.collection_0 s=clone
+    2026-05-21 08:44:59.351 INF Estimated Total Size 24 MB s=clone size_bytes=24220000
+    2026-05-21 08:44:59.351 DBG NumParallelCollections: 2 s=clone
+    2026-05-21 08:44:59.351 INF Config: NumReadWorkers: 3 s=copy
+    2026-05-21 08:44:59.351 INF Config: NumInsertWorkers: 24 s=copy
+    2026-05-21 08:44:59.351 INF Config: SegmentSizeBytes: 1000000000 (1.0 GB) s=copy
     ```
 
 ## Environment variables

--- a/docs/install/parameters.md
+++ b/docs/install/parameters.md
@@ -27,40 +27,6 @@ When [starting the `pcsm` process](start-pcsm.md), you can use the following opt
         --log-json
     ```
 
-    **--clone-segment-size**
-
-    ```{.bash data-prompt="$"}
-    $ pcsm start --clone-segment-size=1G
-    {
-    "ok": true
-    }
-    ```
-
-    Check the logs
-
-    ```
-    2026-05-21 08:34:50.989 INF Starting HTTP server at     http://localhost:2242
-    2026-05-21 08:37:22.475 INF GET /status s=http
-    2026-05-21 08:43:56.309 INF GET /status s=http
-    2026-05-21 08:44:59.346 INF POST /start s=http
-    2026-05-21 08:44:59.347 INF Config: NumWorkers: 12 s=repl
-    2026-05-21 08:44:59.347 INF Config: UseCollectionBulkWrite: false s=repl
-    2026-05-21 08:44:59.347 INF Config: ChangeStreamBatchSize: 10000 s=repl
-    2026-05-21 08:44:59.347 INF Config: EventQueueSize: 5000 s=repl
-    2026-05-21 08:44:59.347 INF Config: WorkerQueueSize: 5000 s=repl
-    2026-05-21 08:44:59.347 INF Config: BulkOpsSize: 5000 s=repl
-    2026-05-21 08:44:59.347 INF Config: WorkerFlushInterval: 1s s=repl
-    2026-05-21 08:44:59.347 INF Config: WorkerBulkQueueSize: 3 s=repl
-    2026-05-21 08:44:59.347 INF Starting Cluster Replication s=pcsm
-    2026-05-21 08:44:59.347 INF Starting Data Clone s=clone
-    2026-05-21 08:44:59.349 INF Namespace "test_db.collection_0" included ns=test_db.collection_0 s=clone
-    2026-05-21 08:44:59.351 INF Estimated Total Size 24 MB s=clone size_bytes=24220000
-    2026-05-21 08:44:59.351 DBG NumParallelCollections: 2 s=clone
-    2026-05-21 08:44:59.351 INF Config: NumReadWorkers: 3 s=copy
-    2026-05-21 08:44:59.351 INF Config: NumInsertWorkers: 24 s=copy
-    2026-05-21 08:44:59.351 INF Config: SegmentSizeBytes: 1000000000 (1.0 GB) s=copy
-    ```
-
 ## Environment variables
 
 Alternatively, you can define the following environment variables:

--- a/docs/install/parameters.md
+++ b/docs/install/parameters.md
@@ -39,9 +39,11 @@ Alternatively, you can define the following environment variables:
 | `PCSM_CLONE_NUM_PARALLEL_COLLECTIONS` | Number of collections cloned in parallel | `2` |
 | `PCSM_CLONE_NUM_READ_WORKERS` | Number of read workers for cloning | `NumCPU / 4` |
 | `PCSM_CLONE_NUM_INSERT_WORKERS` | Number of insert workers for cloning | `NumCPU * 4` |
+| `PCSM_CLONE_SEGMENT_SIZE` | Segment size for clone operations. Accepts plain bytes or a unit suffix (e.g. `500MB`, `1GiB`). When not set, segment size is calculated automatically based on collection size and available read workers. | - |
 | `PCSM_MONGODB_CLI_OPERATION_TIMEOUT` | Maximum time to wait before timing out MongoDB client operations such as insert, update, delete. If the timeout is reached, the operation will fail.  | `5m` | 
 | `PCSM_REPL_NUM_WORKERS` | Controls how many concurrent replication worker goroutines PCSM uses to apply DML (insert/update/replace/delete) events to the target cluster. | `runtime.NumCPU()` |
 | `PCSM_REPL_CHANGE_STREAM_BATCH_SIZE` | Sets the maximum number of change stream events PCSM will request and read from MongoDB per batch while streaming changes from the source cluster. | `10000` |
 | `PCSM_REPL_EVENT_QUEUE_SIZE` | Controls the size of the internal event queue used by the replication subsystem. | `5000` |
 | `PCSM_REPL_WORKER_QUEUE_SIZE` | Defines the maximum number of replication events that each replication worker thread can queue before processing. | `5000` |
 | `PCSM_REPL_BULK_OPS_SIZE` | Defines the maximum number of operations that can be grouped together into a single bulk apply batch during replication. | `5000` |
+

--- a/docs/pcsm-commands.md
+++ b/docs/pcsm-commands.md
@@ -66,7 +66,7 @@ Available flags:
 | `--clone-num-parallel-collections` | Number of collections to copy in parallel during clone. |
 | `--clone-num-read-workers` | Number of read workers that read collection segments from the source. Shared for all collections.|
 | `--clone-num-insert-workers` | Number of insert workers that write batches to the target. Shared for all collections.|
-| `--clone-segment-size` |Defines the size of each clone segment processed during the initial clone phase.
+| `--clone-segment-size` | Defines the size of each clone segment processed during the initial clone phase.|
 | `--repl-num-workers` | Controls how many concurrent replication worker goroutines PCSM uses to apply DML (insert/update/replace/delete) events to the target cluster.|
 | `--repl-change-stream-batch-size`| Sets the maximum number of change stream events PCSM will request and read from MongoDB per batch while streaming changes from the source cluster.|
 | `--repl-event-queue-size`| Controls the size of the internal event queue used by the replication subsystem.|

--- a/docs/pcsm-commands.md
+++ b/docs/pcsm-commands.md
@@ -66,6 +66,7 @@ Available flags:
 | `--clone-num-parallel-collections` | Number of collections to copy in parallel during clone. |
 | `--clone-num-read-workers` | Number of read workers that read collection segments from the source. Shared for all collections.|
 | `--clone-num-insert-workers` | Number of insert workers that write batches to the target. Shared for all collections.|
+| `--clone-segment-size` |Defines the size of each clone segment processed during the initial clone phase.
 | `--repl-num-workers` | Controls how many concurrent replication worker goroutines PCSM uses to apply DML (insert/update/replace/delete) events to the target cluster.|
 | `--repl-change-stream-batch-size`| Sets the maximum number of change stream events PCSM will request and read from MongoDB per batch while streaming changes from the source cluster.|
 | `--repl-event-queue-size`| Controls the size of the internal event queue used by the replication subsystem.|


### PR DESCRIPTION
Auto clone segmentation passes byte count to find().skip().

For more information, refer to the following ticket:

https://perconadev.atlassian.net/browse/PCSM-323